### PR TITLE
Resolves #40: Fix "i" button on Results Page

### DIFF
--- a/frontend/src/pages/Results.jsx
+++ b/frontend/src/pages/Results.jsx
@@ -121,8 +121,10 @@ export const Results = () => {
             {/* Confidence Level Info */}
             <div className="mb-4 relative">
               <button
-                onClick={() => setShowConfidenceInfo(!showConfidenceInfo)}
+                onMouseEnter={() => setShowConfidenceInfo(true)}
+                onMouseLeave={() => setShowConfidenceInfo(false)}
                 className="flex items-center text-sm hover:opacity-80"
+                type="button"
               >
                 <span className="mr-2">ⓘ</span>
                 What is confidence level?


### PR DESCRIPTION
Shows confidence information on hover instead of on click