### PR TITLE
Implemented API Protections

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ async def lifespan(app: FastAPI):
     INTERPRETER, INPUT_INDEX, OUTPUT_INDEX = load_model_from_hub()
     yield
 
+
 # Rate limiter
 limiter = Limiter(key_func=get_remote_address)
 
@@ -74,7 +75,7 @@ def load_model_from_hub():
 
 
 @app.post("/predict/")
-@limiter.limit("50/minute") # 50 requests per minute
+@limiter.limit("50/minute")  # 50 requests per minute
 async def predict(request: Request, file: UploadFile = File(...)):
     # contents = await file.read()
     # preprocessed = preprocess_image(contents)
@@ -84,8 +85,7 @@ async def predict(request: Request, file: UploadFile = File(...)):
 
     if not file.filename.lower().endswith((".jpg", ".jpeg", ".png")):
         raise HTTPException(
-            status_code=400,
-            detail="Only JPG and PNG files are allowed."
+            status_code=400, detail="Only JPG and PNG files are allowed."
         )
 
     contents = await file.read()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,8 @@
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, UploadFile, File, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv; load_dotenv()
+from dotenv import load_dotenv
+
+load_dotenv()
 from model import predict_image
 from utils import preprocess_image
 from huggingface_hub import hf_hub_download
@@ -8,6 +10,10 @@ import tensorflow as tf
 from contextlib import asynccontextmanager
 import os
 import tensorflow as tf
+
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 
 os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
@@ -17,36 +23,45 @@ INTERPRETER = None
 INPUT_INDEX = None
 OUTPUT_INDEX = None
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global INTERPRETER, INPUT_INDEX, OUTPUT_INDEX
     INTERPRETER, INPUT_INDEX, OUTPUT_INDEX = load_model_from_hub()
     yield
 
+# Rate limiter
+limiter = Limiter(key_func=get_remote_address)
 
 app = FastAPI(lifespan=lifespan)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # Allow frontend to call backend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "https://melanoma-detector.vercel.app", "https://melanoma-project.onrender.com" ], 
+    allow_origins=[
+        "http://localhost:3000",
+        "https://melanoma-detector.vercel.app",
+        "https://melanoma-project.onrender.com",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+
 @app.get("/")
 def root():
     return {"message": "Melanoma detection API is live!"}
 
+
 def load_model_from_hub():
-    repo_id = os.environ["MODEL_REPO"]           
+    repo_id = os.environ["MODEL_REPO"]
     filename = os.getenv("MODEL_FILENAME", "melanoma_combo_model.keras")
 
     local_path = hf_hub_download(
-        repo_id=repo_id,
-        filename=filename,          
-        token=os.getenv("HF_TOKEN") 
+        repo_id=repo_id, filename=filename, token=os.getenv("HF_TOKEN")
     )
 
     interpreter = tf.lite.Interpreter(model_path=local_path)
@@ -57,13 +72,21 @@ def load_model_from_hub():
 
     return interpreter, input_index, output_index
 
+
 @app.post("/predict/")
-async def predict(file: UploadFile = File(...)):
+@limiter.limit("50/minute") # 50 requests per minute
+async def predict(request: Request, file: UploadFile = File(...)):
     # contents = await file.read()
     # preprocessed = preprocess_image(contents)
     # confidence = predict_image(preprocessed)
     # label = "Melanoma" if confidence > 0.75 else "Non-Melanoma"
     # return {"prediction": label, "confidence": confidence}
+
+    if not file.filename.lower().endswith((".jpg", ".jpeg", ".png")):
+        raise HTTPException(
+            status_code=400,
+            detail="Only JPG and PNG files are allowed."
+        )
 
     contents = await file.read()
     preprocessed = preprocess_image(contents)  # shape (224, 224, 3)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ numpy
 tensorflow-cpu
 opencv-python-headless
 python-multipart
+slowapi


### PR DESCRIPTION
- Added slowapi library for rate limiting, set /predict endpoint to 50 requests per minute
- Implemented a check in the /predict endpoint, only allows files with .jpg, .jpeg, or .png
- You can test with fastAPI built in swagger ui docs at http://127.0.0.1:8000/docs#/

Closes #46 